### PR TITLE
Disable keyboard handlers for Popover in FiltersMultiSelect and Typeahead components

### DIFF
--- a/packages/core/src/components/FiltersMultiSelect/FiltersMultiSelect.tsx
+++ b/packages/core/src/components/FiltersMultiSelect/FiltersMultiSelect.tsx
@@ -95,6 +95,7 @@ export const FiltersMultiSelect = ({
         )}
         <Field.Control controlRef={inputRef}>
           <Popover
+            keyboardHandlers={false}
             floatingOptions={{
               onOpenChange: (open, event, reason) => {
                 if (disabled) return;

--- a/packages/core/src/components/Popover/hooks/usePopover.tsx
+++ b/packages/core/src/components/Popover/hooks/usePopover.tsx
@@ -20,6 +20,7 @@ export const usePopover: UsePopover = ({
   modal,
   open: controlledOpen,
   onOpenChange: setControlledOpen,
+  keyboardHandlers = true,
   floatingOptions = {},
   interactionsEnabled = 'click',
 }: PopoverOptions = {}) => {
@@ -53,6 +54,7 @@ export const usePopover: UsePopover = ({
   const click = useClick(context, {
     enabled:
       controlledOpen == null && ['click', 'both'].includes(interactionsEnabled),
+    keyboardHandlers,
   });
   const dismiss = useDismiss(context, {
     referencePress: true,

--- a/packages/core/src/components/Popover/types.ts
+++ b/packages/core/src/components/Popover/types.ts
@@ -14,6 +14,7 @@ export interface PopoverOptions {
   open?: boolean;
   floatingOptions?: Partial<UseFloatingOptions>;
   interactionsEnabled?: InteractionsEnabled;
+  keyboardHandlers?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
 

--- a/packages/core/src/components/Typeahead/Typeahead.tsx
+++ b/packages/core/src/components/Typeahead/Typeahead.tsx
@@ -91,6 +91,7 @@ export const Typeahead = ({
           </Label>
         )}
         <Popover
+          keyboardHandlers={false}
           floatingOptions={{
             onOpenChange: hookResult.handleOpenChange,
             open: hookResult.isOpen,


### PR DESCRIPTION
`keyboardHandlers=true` intercepts the Enter and Space events, preventing the space symbol from being entered