### PR TITLE
fix: display the latest selected data point value for BigNumber chart

### DIFF
--- a/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.tsx
+++ b/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.tsx
@@ -48,10 +48,6 @@ export const BigNumberChartComponent = ({
     setHoveredValueThrottled(data.data);
   };
 
-  const handleMouseLeave = () => {
-    setHoveredValueThrottled(null);
-  };
-
   const value = hoveredValue ?? lastValue;
 
   return (
@@ -80,7 +76,7 @@ export const BigNumberChartComponent = ({
               {...trendLineProps}
               data={[{ id: 'trend-line', data }]}
               onMouseMove={handleMouseMove}
-              onMouseLeave={handleMouseLeave}
+              lastActivePoint={value}
             />
           </div>
         </div>

--- a/packages/core/src/components/Charts/BigNumberChart/components/TrendLine.tsx
+++ b/packages/core/src/components/Charts/BigNumberChart/components/TrendLine.tsx
@@ -5,6 +5,7 @@ import {
   Layer,
   LineProps,
   Point,
+  Datum,
   ResponsiveLine,
 } from '@nivo/line';
 import { TrendLineTooltip, TrendLineTooltipProps } from './TrendLineTooltip';
@@ -12,32 +13,45 @@ import { TrendLineTooltip, TrendLineTooltipProps } from './TrendLineTooltip';
 export interface TrendLineProps extends LineProps {
   color?: string;
   tooltipValueFormat?: TrendLineTooltipProps['valueFormat'];
+  lastActivePoint?: Datum;
 }
 
-type CurrentPoint = {
+type ActivePointExtraProps = {
   currentPoint: Point;
+  lastActivePoint?: Datum;
 };
 
 const ActivePoint = ({
   currentPoint,
+  lastActivePoint,
+  points,
   ...props
-}: CustomLayerProps & CurrentPoint) => (
-  <g>
-    {currentPoint && (
-      <DotsItem
-        size={props.pointSize || 10}
-        borderWidth={props.pointBorderWidth || 10}
-        key={currentPoint.id}
-        x={currentPoint.x}
-        y={currentPoint.y}
-        datum={currentPoint.data}
-        color={currentPoint.color}
-        borderColor={currentPoint.borderColor}
-        labelYOffset={props.pointLabelYOffset}
-      />
-    )}
-  </g>
-);
+}: CustomLayerProps & ActivePointExtraProps) => {
+  const activePoint = lastActivePoint
+    ? points.find(
+        ({ data }) =>
+          data.x === lastActivePoint.x && data.y === lastActivePoint.y,
+      )
+    : currentPoint;
+
+  return (
+    <g>
+      {activePoint && (
+        <DotsItem
+          size={props.pointSize || 10}
+          borderWidth={props.pointBorderWidth || 10}
+          key={activePoint.id}
+          x={activePoint.x}
+          y={activePoint.y}
+          datum={activePoint.data}
+          color={activePoint.color}
+          borderColor={activePoint.borderColor}
+          labelYOffset={props.pointLabelYOffset}
+        />
+      )}
+    </g>
+  );
+};
 
 export const TrendLine = ({
   color,


### PR DESCRIPTION
By default, we highlight the last point in a dataset as an active one:
<img width="936" height="210" alt="Снимок экрана 2025-09-02 в 14 31 19" src="https://github.com/user-attachments/assets/e45ca9e9-4743-4544-9a1f-2b86dddf5077" />

After hovering the elements on the chart, we keep the last hovered point selected:
<img width="932" height="214" alt="Снимок экрана 2025-09-02 в 14 31 28" src="https://github.com/user-attachments/assets/bab39eae-98ba-4298-a2c5-03b2a1c9f38b" />

https://github.com/ssagroup/ui-kit/issues/453

