### PR TITLE
Fix/title 597

### DIFF
--- a/packages/core/src/components/Charts/BarGaugeChart/BarGaugeChart.stories.tsx
+++ b/packages/core/src/components/Charts/BarGaugeChart/BarGaugeChart.stories.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { type StoryObj, type Meta } from '@storybook/react-webpack5';
 import { useTheme } from '@emotion/react';
 
+import Icon from '@components/Icon';
 import { BarGaugeChart } from './BarGaugeChart';
 import {
   GaugeBarProps,
@@ -78,6 +79,17 @@ export const WithoutHeader: Story = { args: { features: [] } };
 export const FillScreen: Story = {
   args: {
     features: ['header', 'fullscreenMode'],
+  },
+};
+
+export const WithJsxTitle: Story = {
+  args: {
+    title: (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        BarGauge Chart
+        <Icon name="information" size={16} />
+      </div>
+    ),
   },
 };
 

--- a/packages/core/src/components/Charts/BarGaugeChart/BarGaugeChart.stories.tsx
+++ b/packages/core/src/components/Charts/BarGaugeChart/BarGaugeChart.stories.tsx
@@ -83,6 +83,15 @@ export const FillScreen: Story = {
 };
 
 export const WithJsxTitle: Story = {
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `title` prop accepts any React node. This example shows an icon embedded alongside the chart title text.',
+      },
+    },
+  },
   args: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>

--- a/packages/core/src/components/Charts/BarGaugeChart/types.ts
+++ b/packages/core/src/components/Charts/BarGaugeChart/types.ts
@@ -27,7 +27,7 @@ export interface GaugeBarProps {
 }
 
 export interface BarGaugeChartProps {
-  title?: string;
+  title?: React.ReactNode;
   widgetCardProps?: WidgetCardProps;
   bars?: GaugeBarProps[];
   features?: BarGaugeChartFeature[];

--- a/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.spec.tsx
+++ b/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.spec.tsx
@@ -30,7 +30,7 @@ jest.mock('react-plotly.js', () => ({
 
 describe('BarLineComplexChart', () => {
   it('Should render with title', () => {
-    const { getByTestId } = render(
+    const { getByText } = render(
       <BarLineComplexChart
         data={mockData}
         width="670px"
@@ -41,10 +41,8 @@ describe('BarLineComplexChart', () => {
       />,
     );
 
-    const chart = getByTestId('plotly-chart');
-    const layout = JSON.parse(chart.getAttribute('data-layout') || '{}');
-
-    expect(layout.title?.text).toBe('Bar & Line Complex Chart');
+    // Title is rendered as a DOM overlay above the Plotly canvas, not via layout.title
+    expect(getByText('Bar & Line Complex Chart')).toBeInTheDocument();
   });
 
   describe('Horizontal orientation', () => {

--- a/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.stories.tsx
+++ b/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { TranslationProvider } from '@contexts';
+import Icon from '@components/Icon';
 import { BarLineComplexChart } from './BarLineComplexChart';
 import {
   mockBigData,
@@ -33,6 +34,7 @@ export const Default: Args = {
       height="220px"
       cardProps={{
         title: 'Bar & Line Complex Chart',
+        ...(args.cardProps ?? {}),
       }}
       {...args}
     />
@@ -139,6 +141,24 @@ export const Horizontal: Args = {
     features: ['filtering', 'fullscreenMode'],
     systemModeBarButtons: [],
     maxVisibleBars: 8,
+  },
+};
+
+export const WithJsxTitle: Args = {
+  ...Default,
+  args: {
+    data: mockDataHorizontal,
+    features: ['filtering', 'fullscreenMode'],
+    systemModeBarButtons: [],
+    maxVisibleBars: 8,
+    cardProps: {
+      title: (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          Bar & Line Complex Chart
+          <Icon name="information" size={16} />
+        </div>
+      ),
+    },
   },
 };
 

--- a/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.stories.tsx
+++ b/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.stories.tsx
@@ -146,6 +146,15 @@ export const Horizontal: Args = {
 
 export const WithJsxTitle: Args = {
   ...Default,
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `cardProps.title` prop accepts any React node. The title is rendered as a DOM overlay above the Plotly canvas so JSX (icons, tooltips, etc.) is fully supported.',
+      },
+    },
+  },
   args: {
     data: mockDataHorizontal,
     features: ['filtering', 'fullscreenMode'],

--- a/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.tsx
+++ b/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChart.tsx
@@ -21,6 +21,11 @@ const BarLineComplexChartComponent = ({
   onFullscreenModeChange,
   ...rest
 }: BarLineComplexChartProps) => {
+  const effectiveTitle = cardProps?.title ?? title;
+  const effectiveFeatures =
+    effectiveTitle && !features.includes('header')
+      ? ([...features, 'header'] as BarLineComplexChartProps['features'])
+      : features;
   const tooltip = useTooltip();
   const { isFullscreenMode, setFullscreenMode } = useFullscreenMode();
   const [componentData, setComponentData] = useState<BarLineChartItem[]>(data);
@@ -44,13 +49,13 @@ const BarLineComplexChartComponent = ({
       lineShape={lineShape}
       maxVisibleBars={maxVisibleBars}
       maxVisibleLines={maxVisibleLines}
-      features={features}>
+      features={effectiveFeatures}>
       <TooltipContext.Provider value={tooltip}>
         <BarLineComplexChartInternal
           {...rest}
           cardProps={{
             ...cardProps,
-            title: cardProps?.title || title,
+            title: effectiveTitle,
           }}
         />
       </TooltipContext.Provider>

--- a/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChartView.tsx
+++ b/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChartView.tsx
@@ -159,7 +159,7 @@ export const BarLineComplexChartView = ({
       className="bar-line-complex-chart-wrapper"
       ref={plotlyWrapperRef}
       css={{
-        position: isFullscreenMode ? 'fixed' : 'static',
+        position: isFullscreenMode ? 'fixed' : 'relative',
         top: isFullscreenMode ? '2.5%' : 'unset',
         left: isFullscreenMode ? '2.5%' : 'unset',
         width: isFullscreenMode ? '95%' : width,
@@ -167,8 +167,8 @@ export const BarLineComplexChartView = ({
         borderRadius: 20,
         zIndex: isFullscreenMode ? 2 : 1,
         overflow: 'hidden',
+        background: theme.colors.white,
         boxShadow: 'rgba(42, 48, 57, 0.08) 0px 10px 40px 0px',
-        flexDirection: 'column',
         '& .plotly': {
           '& > div': isFullscreenMode && {
             width: '100% !important',
@@ -182,11 +182,25 @@ export const BarLineComplexChartView = ({
         },
       }}>
       {features?.includes('header') && props.cardProps?.title && (
-        <CardHeader css={{ padding: '12px 20px 0' }}>
+        <CardHeader
+          css={{
+            position: 'absolute',
+            top: isFullscreenMode ? '13px' : '10px',
+            left: '10px',
+            width: 'auto',
+            marginBottom: 0,
+            zIndex: 1,
+          }}>
           <WidgetCardTitle
             variant="h3"
             weight="bold"
-            css={{ flexDirection: 'row', width: '100%' }}>
+            css={{
+              flexDirection: 'row',
+              fontSize: isFullscreenMode ? '24px' : '12px',
+              [theme.mediaQueries.md]: {
+                fontSize: isFullscreenMode ? '24px' : '16px',
+              },
+            }}>
             {props.cardProps.title}
           </WidgetCardTitle>
         </CardHeader>
@@ -211,9 +225,14 @@ export const BarLineComplexChartView = ({
           orientation: 1,
           margin: {
             b: isFullscreenMode ? 15 : 0,
-            l: orientation === 'v' ? 40 : isFullscreenMode ? 30 : 15,
+            l: orientation === 'v' ? 10 : isFullscreenMode ? 30 : 15,
             r: orientation === 'v' ? 40 : 0,
-            t: 10,
+            t:
+              features?.includes('header') && props.cardProps?.title
+                ? isFullscreenMode
+                  ? 45
+                  : 43
+                : 10,
             pad: 10,
             ...margin,
           },

--- a/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChartView.tsx
+++ b/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChartView.tsx
@@ -154,6 +154,10 @@ export const BarLineComplexChartView = ({
       window.removeEventListener('resize', handleDebouncedFn, false);
     };
   }, []);
+  // title is rendered as an absolutely positioned overlay so it shares the same
+  // visual row as Plotly's mode bar buttons, matching the original Plotly title behavior.
+  // Plotly does not support JSX in layout.title, so this DOM overlay is used instead.
+  // The Wrapper is kept `position: relative` so the overlay coordinates are relative to the chart.
   return (
     <Wrapper
       className="bar-line-complex-chart-wrapper"

--- a/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChartView.tsx
+++ b/packages/core/src/components/Charts/BarLineComplexChart/BarLineComplexChartView.tsx
@@ -1,17 +1,13 @@
 import { RefObject, useEffect, useRef, useState } from 'react';
 import Plot from 'react-plotly.js';
 import { useTheme } from '@emotion/react';
-import { debounce, pathOr, propOr } from '@ssa-ui-kit/utils';
-import { useDeviceType } from '@ssa-ui-kit/hooks';
+import { debounce, pathOr } from '@ssa-ui-kit/utils';
 import Wrapper from '@components/Wrapper';
+import CardHeader from '@components/CardHeader';
+import { WidgetCardTitle } from '@components/WidgetCard';
 import { useTooltipContext } from '@components/Tooltip/useTooltipContext';
 import { BarLineComplexChartTooltip } from './BarLineComplexChartTooltip';
-import {
-  FONT_FAMILY,
-  TITLE_FONT_SIZE,
-  TITLE_PADDING_LEFT,
-  TITLE_PADDING_TOP,
-} from './constants';
+import { FONT_FAMILY } from './constants';
 import { usePlotlyDefaultConfig } from '../hooks';
 import { useBarLineComplexChartContext } from './BarLIneComplexChart.context';
 import { BarLineChartItem, BarLineComplexInternalProps } from './types';
@@ -43,7 +39,6 @@ export const BarLineComplexChartView = ({
   const theme = useTheme();
   const plotlyWrapperRef = useRef<HTMLDivElement>(null);
   const plotlyDefaultLayoutConfig = usePlotlyDefaultConfig();
-  const deviceType = useDeviceType();
   const { data } = useBarLineComplexChartContext();
   const orientation = pathOr<BarLineChartItem[], 'h' | 'v'>('v', [
     0,
@@ -61,17 +56,17 @@ export const BarLineComplexChartView = ({
   const [debouncedFn, cancel] = debounceThrottled.current;
   const { setIsOpen } = useTooltipContext();
 
+  const { features } = useBarLineComplexChartContext();
+
   const { layout = {}, config = {}, ...restProps } = props;
   const {
     margin = {},
-    title = {},
-    titlefont = {},
     yaxis = {},
     yaxis2 = {},
     xaxis = {},
     legend = {},
     ...layoutRest
-  } = layout as typeof layout & { titlefont?: Record<string, unknown> };
+  } = layout;
 
   const tickFont = {
     color: theme.colors.greyDarker,
@@ -79,14 +74,6 @@ export const BarLineComplexChartView = ({
     size: isFullscreenMode ? 16 : 12,
     weight: 500,
   };
-
-  if (
-    typeof props.cardProps?.title === 'string' &&
-    typeof title !== 'string' &&
-    typeof title.text !== 'string'
-  ) {
-    title.text = props.cardProps.title;
-  }
 
   const formattedTicks = timestamps.map((timestamp, index) => {
     const dateTime = new Date(timestamp);
@@ -181,6 +168,7 @@ export const BarLineComplexChartView = ({
         zIndex: isFullscreenMode ? 2 : 1,
         overflow: 'hidden',
         boxShadow: 'rgba(42, 48, 57, 0.08) 0px 10px 40px 0px',
+        flexDirection: 'column',
         '& .plotly': {
           '& > div': isFullscreenMode && {
             width: '100% !important',
@@ -193,6 +181,16 @@ export const BarLineComplexChartView = ({
           },
         },
       }}>
+      {features?.includes('header') && props.cardProps?.title && (
+        <CardHeader css={{ padding: '12px 20px 0' }}>
+          <WidgetCardTitle
+            variant="h3"
+            weight="bold"
+            css={{ flexDirection: 'row', width: '100%' }}>
+            {props.cardProps.title}
+          </WidgetCardTitle>
+        </CardHeader>
+      )}
       <Plot
         divId={'bar-line-complex-chart-graph'}
         css={{
@@ -213,51 +211,12 @@ export const BarLineComplexChartView = ({
           orientation: 1,
           margin: {
             b: isFullscreenMode ? 15 : 0,
-            l:
-              orientation === 'v'
-                ? propOr(
-                    TITLE_PADDING_LEFT.other,
-                    deviceType,
-                  )(TITLE_PADDING_LEFT)
-                : isFullscreenMode
-                  ? 30
-                  : 15,
+            l: orientation === 'v' ? 40 : isFullscreenMode ? 30 : 15,
             r: orientation === 'v' ? 40 : 0,
-            t:
-              propOr(TITLE_PADDING_TOP.other, deviceType)(TITLE_PADDING_TOP) +
-              25,
+            t: 10,
             pad: 10,
             ...margin,
           },
-          title:
-            typeof title === 'string'
-              ? title
-              : {
-                  x: 0,
-                  y: 1,
-                  font: {
-                    size: isFullscreenMode
-                      ? 24
-                      : propOr(
-                          TITLE_FONT_SIZE.other,
-                          deviceType,
-                        )(TITLE_FONT_SIZE),
-                    weight: 700,
-                    family: FONT_FAMILY,
-                    ...titlefont,
-                  },
-                  pad: {
-                    l: propOr(
-                      TITLE_PADDING_LEFT.other,
-                      deviceType,
-                    )(TITLE_PADDING_LEFT),
-                    t: propOr(
-                      TITLE_PADDING_TOP.other,
-                      deviceType,
-                    )(TITLE_PADDING_TOP),
-                  },
-                  ...title,
-                },
           barmode: 'group',
           autosize: false,
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/core/src/components/Charts/BarLineComplexChart/constants.ts
+++ b/packages/core/src/components/Charts/BarLineComplexChart/constants.ts
@@ -1,16 +1,1 @@
 export const FONT_FAMILY = 'Manrope, sans-serif';
-export const TITLE_PADDING_LEFT = {
-  mobile: 10,
-  md: 10,
-  other: 20,
-};
-export const TITLE_PADDING_TOP = {
-  mobile: 13,
-  md: 18,
-  other: 20,
-};
-export const TITLE_FONT_SIZE = {
-  mobile: 16,
-  md: 16,
-  other: 20,
-};

--- a/packages/core/src/components/Charts/BarLineComplexChart/types.ts
+++ b/packages/core/src/components/Charts/BarLineComplexChart/types.ts
@@ -21,7 +21,7 @@ export interface BarLineComplexChartProps extends Omit<PlotParams, 'layout'> {
   lineShape?: Plotly.ScatterLine['shape'];
   width?: string;
   height?: string;
-  title?: string;
+  title?: React.ReactNode;
   maxVisibleBars?: number;
   maxVisibleLines?: number;
   container?: Element | DocumentFragment;

--- a/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.stories.tsx
+++ b/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.stories.tsx
@@ -76,6 +76,15 @@ export const NonInteractive: Story = {
 };
 
 export const WithJsxTitle: Story = {
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `title` prop accepts any React node. This example shows an icon embedded alongside the chart title text.',
+      },
+    },
+  },
   args: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>

--- a/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.stories.tsx
+++ b/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.stories.tsx
@@ -3,6 +3,7 @@ import { type StoryObj, type Meta } from '@storybook/react-webpack5';
 import { DateTime } from 'luxon';
 import { seededRandom } from '@ssa-ui-kit/utils';
 
+import Icon from '@components/Icon';
 import { BigNumberChart } from './';
 
 const generateMockData = (): Array<{ x: number | null; y: number | null }> => {
@@ -71,6 +72,17 @@ export const FillScreen: Story = {
 export const NonInteractive: Story = {
   args: {
     interactive: false,
+  },
+};
+
+export const WithJsxTitle: Story = {
+  args: {
+    title: (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        BigNumber Chart
+        <Icon name="information" size={16} />
+      </div>
+    ),
   },
 };
 

--- a/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.tsx
+++ b/packages/core/src/components/Charts/BigNumberChart/BigNumberChart.tsx
@@ -12,7 +12,7 @@ type Datum = LineSeries['data'][number];
 export interface BigNumberChartProps {
   data: Datum[];
   interactive?: boolean;
-  title?: string;
+  title?: React.ReactNode;
   widgetCardProps?: WidgetCardProps;
   trendLineProps?: Omit<TrendLineProps, 'data' | 'height' | 'width'>;
   features?: BigNumberChartFeatures[];

--- a/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.stories.tsx
+++ b/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.stories.tsx
@@ -79,6 +79,15 @@ export const Fullscreen: Story = {
 };
 
 export const WithJsxTitle: Story = {
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `title` prop accepts any React node. The title is rendered as a DOM overlay above the Plotly canvas so JSX (icons, tooltips, etc.) is fully supported.',
+      },
+    },
+  },
   args: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>

--- a/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.stories.tsx
+++ b/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.stories.tsx
@@ -2,6 +2,7 @@ import { type StoryObj, type Meta } from '@storybook/react-webpack5';
 import { DateTime } from 'luxon';
 import { seededRandom } from '@ssa-ui-kit/utils';
 
+import Icon from '@components/Icon';
 import { CandlestickChart, CandlestickChartProps } from './';
 
 const generateMockData = (count = 60, stepMinutes = 1) => {
@@ -74,6 +75,17 @@ export const Japanese: Story = {
 export const Fullscreen: Story = {
   args: {
     features: ['fullscreenMode', 'header'],
+  },
+};
+
+export const WithJsxTitle: Story = {
+  args: {
+    title: (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        Candlestick Chart
+        <Icon name="information" size={16} />
+      </div>
+    ),
   },
 };
 

--- a/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.tsx
+++ b/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.tsx
@@ -69,13 +69,16 @@ export const CandlestickChartComponent = ({
   }
 
   return (
+    // title is rendered as an absolutely positioned overlay so it shares the same
+    // visual row as Plotly's mode bar buttons, matching the original Plotly title behavior.
+    // Plotly does not support JSX in layout.title, so this DOM overlay is used instead.
     <WithWidgetCard features={features} cardProps={{ ...widgetCardProps }}>
       <div css={{ position: 'relative', width: '100%', height: '100%' }}>
         {title && (
           <CardHeader
             css={{
               position: 'absolute',
-              top: '10px',
+              top: '1px',
               left: '10px',
               width: 'auto',
               marginBottom: 0,
@@ -103,7 +106,7 @@ export const CandlestickChartComponent = ({
             xaxis: { rangeslider: { visible: false } },
             yaxis: { side: 'right' },
             margin: {
-              t: 30,
+              t: 20,
               b: 40,
               l: 20,
               r: 20,

--- a/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.tsx
+++ b/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.tsx
@@ -2,7 +2,12 @@ import { renderToString } from 'react-dom/server';
 import Plot, { PlotParams } from 'react-plotly.js';
 import { useTheme } from '@emotion/react';
 
-import { WidgetCardProps, WithWidgetCard } from '@components/WidgetCard';
+import {
+  WidgetCardProps,
+  WidgetCardTitle,
+  WithWidgetCard,
+} from '@components/WidgetCard';
+import CardHeader from '@components/CardHeader';
 import {
   useFullscreenMode,
   WithFullscreenMode,
@@ -63,54 +68,71 @@ export const CandlestickChartComponent = ({
     });
   }
 
-  const effectiveFeatures =
-    title && !features.includes('header')
-      ? ([...features, 'header'] as CandlestickChartFeatures[])
-      : features;
-
   return (
-    <WithWidgetCard
-      features={effectiveFeatures}
-      cardProps={{
-        title,
-        ...widgetCardProps,
-      }}>
-      <Plot
-        layout={{
-          ...plotlyDefaultLayoutConfig.layout,
-          dragmode: 'zoom',
-          xaxis: { rangeslider: { visible: false } },
-          yaxis: { side: 'right' },
-          margin: {
-            t: 10,
-            b: 40,
-            l: 20,
-            r: 20,
-          },
-          showlegend: false,
-          ...layout,
-        }}
-        css={{ width: '100%', height: '100%' }}
-        useResizeHandler
-        data={plotData}
-        config={{
-          ...plotlyDefaultLayoutConfig.config,
-          modeBarButtons: [
-            extraModeBarButtons,
-            [
-              'zoom2d',
-              'pan2d',
-              'select2d',
-              'zoomIn2d',
-              'zoomOut2d',
-              'autoScale2d',
-              'resetScale2d',
+    <WithWidgetCard features={features} cardProps={{ ...widgetCardProps }}>
+      <div css={{ position: 'relative', width: '100%', height: '100%' }}>
+        {title && (
+          <CardHeader
+            css={{
+              position: 'absolute',
+              top: '10px',
+              left: '10px',
+              width: 'auto',
+              marginBottom: 0,
+              zIndex: 1,
+            }}>
+            <WidgetCardTitle
+              variant="h3"
+              weight="bold"
+              css={{
+                flexDirection: 'row',
+                lineHeight: 1,
+                fontSize: '24px',
+                [theme.mediaQueries.md]: {
+                  fontSize: '24px',
+                },
+              }}>
+              {title}
+            </WidgetCardTitle>
+          </CardHeader>
+        )}
+        <Plot
+          layout={{
+            ...plotlyDefaultLayoutConfig.layout,
+            dragmode: 'zoom',
+            xaxis: { rangeslider: { visible: false } },
+            yaxis: { side: 'right' },
+            margin: {
+              t: 30,
+              b: 40,
+              l: 20,
+              r: 20,
+            },
+            showlegend: false,
+            ...layout,
+          }}
+          css={{ width: '100%', height: '100%' }}
+          useResizeHandler
+          data={plotData}
+          config={{
+            ...plotlyDefaultLayoutConfig.config,
+            modeBarButtons: [
+              extraModeBarButtons,
+              [
+                'zoom2d',
+                'pan2d',
+                'select2d',
+                'zoomIn2d',
+                'zoomOut2d',
+                'autoScale2d',
+                'resetScale2d',
+              ],
             ],
-          ],
-          ...config,
-        }}
-        {...restPlotParams}
-      />
+            ...config,
+          }}
+          {...restPlotParams}
+        />
+      </div>
     </WithWidgetCard>
   );
 };

--- a/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.tsx
+++ b/packages/core/src/components/Charts/CandlestickChart/CandlestickChart.tsx
@@ -23,7 +23,7 @@ export interface CandlestickChartProps extends Partial<
 > {
   data: CandlestickChartData;
   style?: CandlestickStyle;
-  title?: string;
+  title?: React.ReactNode;
   features?: CandlestickChartFeatures[];
   widgetCardProps?: WidgetCardProps;
 }
@@ -31,7 +31,7 @@ export interface CandlestickChartProps extends Partial<
 export const CandlestickChartComponent = ({
   title,
   data,
-  features,
+  features = [],
   widgetCardProps,
   style = 'hollow',
   ...plotParams
@@ -63,34 +63,26 @@ export const CandlestickChartComponent = ({
     });
   }
 
+  const effectiveFeatures =
+    title && !features.includes('header')
+      ? ([...features, 'header'] as CandlestickChartFeatures[])
+      : features;
+
   return (
     <WithWidgetCard
-      features={features}
+      features={effectiveFeatures}
       cardProps={{
+        title,
         ...widgetCardProps,
       }}>
       <Plot
         layout={{
           ...plotlyDefaultLayoutConfig.layout,
-          title: {
-            text: title,
-            x: 0,
-            y: 1,
-            pad: {
-              l: 10,
-              t: 5,
-            },
-            font: {
-              size: 24,
-              weight: 700,
-              family: 'Manrope, sans-serif',
-            },
-          },
           dragmode: 'zoom',
           xaxis: { rangeslider: { visible: false } },
           yaxis: { side: 'right' },
           margin: {
-            t: 20,
+            t: 10,
             b: 40,
             l: 20,
             r: 20,

--- a/packages/core/src/components/Charts/GaugeChart/GaugeChart.stories.tsx
+++ b/packages/core/src/components/Charts/GaugeChart/GaugeChart.stories.tsx
@@ -68,6 +68,15 @@ export const FillScreen: Story = {
 };
 
 export const WithJsxTitle: Story = {
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `title` prop accepts any React node. This example shows an icon embedded alongside the chart title text.',
+      },
+    },
+  },
   args: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>

--- a/packages/core/src/components/Charts/GaugeChart/GaugeChart.stories.tsx
+++ b/packages/core/src/components/Charts/GaugeChart/GaugeChart.stories.tsx
@@ -1,5 +1,6 @@
 import { type StoryObj, type Meta } from '@storybook/react-webpack5';
 
+import Icon from '@components/Icon';
 import { GaugeChart } from './';
 
 const meta = {
@@ -63,5 +64,16 @@ export const NoLabels: Story = {
 export const FillScreen: Story = {
   args: {
     features: ['header', 'fullscreenMode'],
+  },
+};
+
+export const WithJsxTitle: Story = {
+  args: {
+    title: (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        Gauge
+        <Icon name="information" size={16} />
+      </div>
+    ),
   },
 };

--- a/packages/core/src/components/Charts/GaugeChart/GaugeChart.tsx
+++ b/packages/core/src/components/Charts/GaugeChart/GaugeChart.tsx
@@ -30,7 +30,7 @@ export interface GaugeChartProps
   minValue: number;
   maxValue: number;
   value: number;
-  title?: string;
+  title?: React.ReactNode;
   segments?: {
     value: number;
     id?: string;

--- a/packages/core/src/components/Charts/PieChart/PieChart.stories.tsx
+++ b/packages/core/src/components/Charts/PieChart/PieChart.stories.tsx
@@ -2,6 +2,7 @@ import { Fragment, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { css, useTheme } from '@emotion/react';
 import { css as cssString } from '@emotion/css';
+import Icon from '@components/Icon';
 import Typography from '@components/Typography';
 import Tooltip from '@components/Tooltip';
 import TooltipTrigger from '@components/TooltipTrigger';
@@ -341,6 +342,31 @@ export const FullscreenAndTitle: StoryObj<typeof PieChart> = () => {
   );
 };
 FullscreenAndTitle.args = {};
+
+export const WithJsxTitle: StoryObj<typeof PieChart> = () => {
+  const theme = useTheme();
+  const { legendColorNames, pieChartColors } =
+    pieChartPalettes.getBalancePalette(theme);
+
+  return (
+    <PieChart
+      data={accountData}
+      colors={pieChartColors}
+      animate={false}
+      features={['header']}
+      cardProps={{
+        title: (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            Pie Chart
+            <Icon name="information" size={16} />
+          </div>
+        ),
+      }}>
+      <PieChartLegend data={accountData} colors={legendColorNames} />
+    </PieChart>
+  );
+};
+WithJsxTitle.args = {};
 
 const WithTooltipTemplate: StoryObj<
   Pick<PieChartProps, 'data' | 'legendOutputType'> & {

--- a/packages/core/src/components/Charts/PieChart/PieChart.stories.tsx
+++ b/packages/core/src/components/Charts/PieChart/PieChart.stories.tsx
@@ -366,7 +366,16 @@ export const WithJsxTitle: StoryObj<typeof PieChart> = () => {
     </PieChart>
   );
 };
+WithJsxTitle.storyName = 'With JSX Title';
 WithJsxTitle.args = {};
+WithJsxTitle.parameters = {
+  docs: {
+    description: {
+      story:
+        'The `cardProps.title` prop accepts any React node. This example shows an icon embedded alongside the chart title text.',
+    },
+  },
+};
 
 const WithTooltipTemplate: StoryObj<
   Pick<PieChartProps, 'data' | 'legendOutputType'> & {

--- a/packages/core/src/components/Charts/RadarChart/RadarChart.stories.tsx
+++ b/packages/core/src/components/Charts/RadarChart/RadarChart.stories.tsx
@@ -63,6 +63,15 @@ export const FullScreen: Story = {
 };
 
 export const WithJsxTitle: Story = {
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `title` prop accepts any React node. This example shows an icon embedded alongside the chart title text.',
+      },
+    },
+  },
   args: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>

--- a/packages/core/src/components/Charts/RadarChart/RadarChart.stories.tsx
+++ b/packages/core/src/components/Charts/RadarChart/RadarChart.stories.tsx
@@ -1,5 +1,6 @@
 import { type StoryObj, type Meta } from '@storybook/react-webpack5';
 
+import Icon from '@components/Icon';
 import { RadarChart } from './';
 
 const meta: Meta<typeof RadarChart> = {
@@ -58,6 +59,17 @@ export const CustomColors: Story = {
 export const FullScreen: Story = {
   args: {
     features: ['header', 'fullscreenMode'],
+  },
+};
+
+export const WithJsxTitle: Story = {
+  args: {
+    title: (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        Radar Chart
+        <Icon name="information" size={16} />
+      </div>
+    ),
   },
 };
 

--- a/packages/core/src/components/Charts/RadarChart/RadarChart.tsx
+++ b/packages/core/src/components/Charts/RadarChart/RadarChart.tsx
@@ -20,7 +20,7 @@ type ResponsiveRadarProps<D extends Record<string, unknown>> = ComponentProps<
 export interface RadarChartProps<
   D extends Record<string, unknown>,
 > extends Omit<ResponsiveRadarProps<D>, 'legends'> {
-  title?: string;
+  title?: React.ReactNode;
   legends?: Partial<NonNullable<ResponsiveRadarProps<D>['legends']>[number]>[];
   features?: RadarChartFeatures[];
   widgetCardProps?: WidgetCardProps;

--- a/packages/core/src/components/Charts/SegmentedPieChart/stories/SegmentedPieChart.stories.tsx
+++ b/packages/core/src/components/Charts/SegmentedPieChart/stories/SegmentedPieChart.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import Icon from '@components/Icon';
 import {
   balanceData,
   balanceMissedPartsData,
@@ -114,6 +115,22 @@ export const FullscreenWithTitle: Story = {
       features: ['header', 'fullscreenMode'],
       cardProps: {
         title: 'Segmented Pie Chart',
+      },
+    },
+  },
+};
+
+export const WithJsxTitle: Story = {
+  args: {
+    pieChartProps: {
+      features: ['header'],
+      cardProps: {
+        title: (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            Segmented Pie Chart
+            <Icon name="information" size={16} />
+          </div>
+        ),
       },
     },
   },

--- a/packages/core/src/components/Charts/SegmentedPieChart/stories/SegmentedPieChart.stories.tsx
+++ b/packages/core/src/components/Charts/SegmentedPieChart/stories/SegmentedPieChart.stories.tsx
@@ -121,6 +121,15 @@ export const FullscreenWithTitle: Story = {
 };
 
 export const WithJsxTitle: Story = {
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `pieChartProps.cardProps.title` prop accepts any React node. This example shows an icon embedded alongside the chart title text.',
+      },
+    },
+  },
   args: {
     pieChartProps: {
       features: ['header'],

--- a/packages/core/src/components/Charts/TreeMapChart/TreeMapChart.stories.tsx
+++ b/packages/core/src/components/Charts/TreeMapChart/TreeMapChart.stories.tsx
@@ -93,6 +93,15 @@ export const FullScreen: Story = {
 };
 
 export const WithJsxTitle: Story = {
+  name: 'With JSX Title',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `title` prop accepts any React node. This example shows an icon embedded alongside the chart title text.',
+      },
+    },
+  },
   args: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>

--- a/packages/core/src/components/Charts/TreeMapChart/TreeMapChart.stories.tsx
+++ b/packages/core/src/components/Charts/TreeMapChart/TreeMapChart.stories.tsx
@@ -1,6 +1,7 @@
 import { type StoryObj, type Meta } from '@storybook/react-webpack5';
 import { css } from '@emotion/css';
 
+import Icon from '@components/Icon';
 import {
   TreeMapChart,
   TreeMapTooltipBase,
@@ -88,6 +89,17 @@ export const CustomColorsCallback: Story = {
 export const FullScreen: Story = {
   args: {
     features: ['header', 'fullscreenMode'],
+  },
+};
+
+export const WithJsxTitle: Story = {
+  args: {
+    title: (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        TreeMap Chart
+        <Icon name="information" size={16} />
+      </div>
+    ),
   },
 };
 

--- a/packages/core/src/components/Charts/TreeMapChart/TreeMapChart.tsx
+++ b/packages/core/src/components/Charts/TreeMapChart/TreeMapChart.tsx
@@ -27,7 +27,7 @@ type NivoTreeMapChartProps = React.ComponentProps<
 >;
 export interface TreeMapChartProps extends Omit<NivoTreeMapChartProps, 'data'> {
   data: TreeNode;
-  title?: string;
+  title?: React.ReactNode;
   fullScreen?: boolean;
   features?: TreeMapChartFeature[];
   widgetCardProps?: WidgetCardProps;

--- a/packages/core/src/components/WidgetCard/WidgetCard.tsx
+++ b/packages/core/src/components/WidgetCard/WidgetCard.tsx
@@ -26,11 +26,9 @@ export const WidgetCard = ({
         isFullscreenMode={isFullscreenMode}
         width={width}
         height={height}>
-        {(title || headerContent) && (
-          <Header title={title} className={headerClassName}>
-            {headerContent}
-          </Header>
-        )}
+        <Header title={title} className={headerClassName}>
+          {headerContent}
+        </Header>
         <Content
           className={contentClassName}
           isFullscreenMode={isFullscreenMode}>

--- a/packages/core/src/components/WidgetCard/WidgetCard.tsx
+++ b/packages/core/src/components/WidgetCard/WidgetCard.tsx
@@ -26,9 +26,11 @@ export const WidgetCard = ({
         isFullscreenMode={isFullscreenMode}
         width={width}
         height={height}>
-        <Header title={title} className={headerClassName}>
-          {headerContent}
-        </Header>
+        {(title || headerContent) && (
+          <Header title={title} className={headerClassName}>
+            {headerContent}
+          </Header>
+        )}
         <Content
           className={contentClassName}
           isFullscreenMode={isFullscreenMode}>


### PR DESCRIPTION
Added ability to pass title as JSX  to all charts
<img width="682" height="235" alt="Screenshot 2026-04-16 at 18 05 00" src="https://github.com/user-attachments/assets/8a57cb22-a317-4955-8ce6-0a9e7fe677e5" />

<img width="1060" height="425" alt="Screenshot 2026-04-16 at 18 05 26" src="https://github.com/user-attachments/assets/8ee87c8e-ae2a-4e2f-a3f9-ad5df422d01f" />

<img width="1410" height="427" alt="Screenshot 2026-04-16 at 18 06 04" src="https://github.com/user-attachments/assets/4a7d4848-0a20-465e-8528-cb92a33e4b01" />

